### PR TITLE
CodonUtils: change behavior of simpleTranslate

### DIFF
--- a/src/main/java/edu/stanford/hivdb/utilities/CodonUtils.java
+++ b/src/main/java/edu/stanford/hivdb/utilities/CodonUtils.java
@@ -387,11 +387,11 @@ public class CodonUtils {
 				String ref = consAAs.substring(firstAA + pos - 1, firstAA + pos);
 				aas = aas.replaceAll(ref, "");
 			}
-			if (aas.length() > 1) {
+			if (aas.length() > 2) {
 				allAAs.append("X");
 			}
 			else {
-				allAAs.append(aas);
+				allAAs.append(aas.substring(0, 1));
 			}
 		}
 		return allAAs.toString();


### PR DESCRIPTION
When handling a mutation mixture, only > 2 should be convert to X. A mixture with two non-consensus amino acids should not be convert to "X" but should use either of the amino acids.